### PR TITLE
Fixed EXECUTE response payload

### DIFF
--- a/firebase/functions/smart-home/fulfillment.js
+++ b/firebase/functions/smart-home/fulfillment.js
@@ -110,10 +110,12 @@ fulfillment.onExecute(async (body, headers) => {
     return {
       requestId: body.requestId,
       payload: {
-        commands: {
-          ids: command.devices.map(device => device.id),
-          status: 'PENDING'
-        }
+        commands: [
+          {
+            ids: command.devices.map(device => device.id),
+            status: 'PENDING'
+          }
+        ]
       }
     };
   } catch (error) {


### PR DESCRIPTION
Per [the documentation](https://actions-on-google.github.io/actions-on-google-nodejs/2.12.0/interfaces/_service_smarthome_api_v1_.smarthomev1executepayload.html#commands), the EXECUTE intent response should contain a list of `commands`.

Failure to match this signature results in Google Assistant responding with "I'm sorry, I couldn't reach `Device Name`. Please try again later" after the EXECUTE intent completes.